### PR TITLE
chore: update copilot instructions with credentials and response style guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -70,6 +70,15 @@ Complex fields (Letters, Labs, Prescriptions, etc.) are intentionally excluded f
 - Update all references when moving files
 - Project root is `n8n-nodes-semble` directory
 
+### Credentials & Environment
+**Development:**
+- Credentials stored in `.env` file at **workspace root**
+- NOT in project root - always reference workspace-level `.env`
+
+**Production:**
+- WordPress-related credentials stored in `wp-config.php`
+- n8n credentials managed through n8n credentials interface
+
 ## Essential Commands
 ```bash
 pnpm install          # Install dependencies

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -56,13 +56,20 @@ Complex fields (Letters, Labs, Prescriptions, etc.) are intentionally excluded f
 4. Not respecting rate limits in polling triggers
 5. Missing GraphQL field validation against official schema
 
+### Response Style - CRITICAL
+**When providing assistance:**
+- Never be sycophantic or simply agree - provide the correct answer or industry best practice, even if it means disagreeing
+- Never guess when you don't know something - explicitly state "I don't know" so we can determine the correct answer together
+- Prioritise accuracy over agreeability
+
 ### British English - CRITICAL
-**All code, comments, and documentation MUST use British English:**
+**All comments and documentation MUST use British English:**
 - optimise (not optimize)
 - colour (not color)
 - customise (not customize)
 - organisation (not organization)
 - **Use -ise suffix, not -ize**
+- Note: Code itself may use American English (standard in programming)
 
 ### File Management
 - Always check if files exist before creating


### PR DESCRIPTION
## Changes
- Added credential location documentation (workspace root `.env` for dev, `wp-config.php` for production)
- Added response style guidance emphasising accuracy over agreeability
- Clarified British English usage (comments/docs only, not code)

## Context
Standardising AI assistant behaviour and credential management documentation across workspace repositories.