### PR TITLE
fix: use X-N8N-API-KEY header and authenticated endpoint for production health check

### DIFF
--- a/scripts/update-n8n.sh
+++ b/scripts/update-n8n.sh
@@ -76,7 +76,7 @@ make_n8n_api_call() {
     local data="$3"
     
     local curl_cmd="curl -s -X $method"
-    curl_cmd="$curl_cmd -H 'Authorization: Bearer $API_KEY'"
+    curl_cmd="$curl_cmd -H 'X-N8N-API-KEY: $API_KEY'"
     curl_cmd="$curl_cmd -H 'Content-Type: application/json'"
     
     if [ -n "$data" ]; then
@@ -313,20 +313,14 @@ get_current_version_api() {
     
     get_api_config "$env" || return 1
     
-    # Try to get version from API health endpoint
-    local response=$(curl -s "$HOST_URL/healthz" 2>/dev/null || echo "")
+    # Use the authenticated API endpoint — avoids Cloudflare Access redirect on /healthz
+    local response=$(curl -s \
+        -H "X-N8N-API-KEY: $API_KEY" \
+        -H "Content-Type: application/json" \
+        "${API_ENDPOINT}workflows?limit=1" 2>/dev/null || echo "")
     
-    if [ -n "$response" ]; then
-        # Try to extract version from response if available
-        local version=$(echo "$response" | grep -o '"version":"[^"]*"' | cut -d'"' -f4 2>/dev/null || echo "")
-        
-        if [ -n "$version" ]; then
-            echo "$version"
-        else
-            # Fallback: try to get from status endpoint
-            local status_response=$(make_n8n_api_call "GET" "/settings" 2>/dev/null || echo "")
-            echo "api-accessible"
-        fi
+    if [ -n "$response" ] && echo "$response" | grep -q '"data"'; then
+        echo "api-accessible"
     else
         echo "unreachable"
     fi


### PR DESCRIPTION
## Summary

Fixes two issues in `scripts/update-n8n.sh` where the script was using the wrong authentication header and an unauthenticated endpoint for the production health check.

## ClickUp Task
CU-869ca8kpj

## Changes

### `make_n8n_api_call()`
- Changed `Authorization: Bearer $API_KEY` → `X-N8N-API-KEY: $API_KEY`
- n8n's REST API requires the `X-N8N-API-KEY` header, not a Bearer token (confirmed against [n8n API auth docs](https://docs.n8n.io/api/authentication/))

### `get_current_version_api()`
- Replaced unauthenticated `curl "$HOST_URL/healthz"` with an authenticated call to `${API_ENDPOINT}workflows?limit=1`
- The `/healthz` endpoint was returning a 302 redirect (blocked by Cloudflare Zero Trust), causing the version check to fail silently
- The workflows endpoint is covered by the CF Access bypass policy for `/api*` paths

## Testing
- Verified API connectivity: `curl -H "X-N8N-API-KEY: ..." "${N8N_PROD_API_ENDPOINT}workflows?limit=1"` returns `{"data":[...]}` ✅
- `npm run update:n8n:production` ran successfully, updating production to **2.14.2** ✅